### PR TITLE
Add restore() that calls mockFn.mockRestore()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,8 +76,12 @@ Clears all spies in the sandbox. Actually calls `.mockClear()` on every spy it k
 
 Resets all spies in the sandbox. Actually calls `.mockReset()` on every spy it keeps track of.
 
+#### `sandbox.restore()`
+
+Restores all spies in the sandbox. Actually calls `.mockRestore()` on every spy it keeps track of.
+
 #### Note
-Keep in mind that you can still clear and reset the single spies manually, like you're used to.
+Keep in mind that you can still clear, reset and restore the single spies manually, like you're used to.
 
 ### Contribute
 

--- a/__tests__/jest-sandbox.test.js
+++ b/__tests__/jest-sandbox.test.js
@@ -66,3 +66,30 @@ test('Resets all mocks', () => {
   expect(x).toBeUndefined();
   expect(y).toBeUndefined();
 });
+
+test('Restores all spies', () => {
+  const sandbox = new JestSandbox();
+  class CoolClass {
+    hello() {
+      return 'hello';
+    }
+  }
+  const fn = sandbox.fn();
+  const spy = sandbox
+    .spyOn(CoolClass.prototype, 'hello')
+    .mockImplementation(() => 'yo, homie');
+  fn('a');
+  expect(fn).toBeCalledWith('a');
+  expect(fn.mock.calls).toHaveLength(1);
+  expect(fn.mock.instances).toHaveLength(1);
+  const cool = new CoolClass();
+  expect(cool.hello()).toBe('yo, homie');
+  expect(spy.mock.calls).toHaveLength(1);
+  expect(spy.mock.instances).toHaveLength(1);
+  sandbox.restore();
+  expect(fn.mock.calls).toHaveLength(1);
+  expect(fn.mock.instances).toHaveLength(1);
+  expect(cool.hello()).toBe('hello');
+  expect(spy.mock.calls).toHaveLength(1);
+  expect(spy.mock.instances).toHaveLength(1);
+});

--- a/__tests__/jest-sandbox.test.js
+++ b/__tests__/jest-sandbox.test.js
@@ -74,22 +74,11 @@ test('Restores all spies', () => {
       return 'hello';
     }
   }
-  const fn = sandbox.fn();
   const spy = sandbox
     .spyOn(CoolClass.prototype, 'hello')
     .mockImplementation(() => 'yo, homie');
-  fn('a');
-  expect(fn).toBeCalledWith('a');
-  expect(fn.mock.calls).toHaveLength(1);
-  expect(fn.mock.instances).toHaveLength(1);
   const cool = new CoolClass();
   expect(cool.hello()).toBe('yo, homie');
-  expect(spy.mock.calls).toHaveLength(1);
-  expect(spy.mock.instances).toHaveLength(1);
   sandbox.restore();
-  expect(fn.mock.calls).toHaveLength(1);
-  expect(fn.mock.instances).toHaveLength(1);
   expect(cool.hello()).toBe('hello');
-  expect(spy.mock.calls).toHaveLength(1);
-  expect(spy.mock.instances).toHaveLength(1);
 });

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ export class JestSandbox {
   reset() {
     this._each('mockReset');
   }
+  restore() {
+    this._each('mockRestore');
+  }
 }
 
 export default () => new JestSandbox();


### PR DESCRIPTION
About mockFn.mockRestore()
https://facebook.github.io/jest/docs/mock-function-api.html#mockfnmockrestore

This is not yet supported in Jest: https://github.com/facebook/jest/issues/2965